### PR TITLE
Check for missing download.log

### DIFF
--- a/get_podcast.sh
+++ b/get_podcast.sh
@@ -27,7 +27,7 @@ local_path="$dir/$name.mp3"
 
 # check if file was downloaded already
 grep $local_path $download_log >/dev/null
-if [ ${?} -eq 1 ]; then
+if [[ ${?} -eq 1 || ${?} -eq 2 ]]; then
     target_path="$target_dir/$local_path"
 # if [ ! -f "$target_path" ]; then
     echo "Downloading the following podcast to $target_path"


### PR DESCRIPTION
This will ensure that the download.log gets created instead of just skipping the download if download.log doesn't exist.

Fixes #4 