### PR TITLE
Add flag "-s" to modify podcast speed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.log
 
 *.code-workspace
+podcasts.sh.lock

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 *~
 *.conf
 *.log
+
+*.code-workspace

--- a/get_podcast.sh
+++ b/get_podcast.sh
@@ -3,18 +3,19 @@ cd $(dirname $0)
 
 download_log="./download.log"
 
-if [ $# -lt 3 ]; then
-    echo "USAGE: $(basename $0) target_dir fixed_name audio_url podcast_name episode_name artwork_url pubdate"
+if [ $# -lt 4 ]; then
+    echo "USAGE: $(basename $0) target_dir speed fixed_name audio_url podcast_name episode_name artwork_url pubdate"
     exit 1
 fi
 
 target_dir="$1"
-rawdir="$2"
-url="$3"
-# rawdir="$4"  # ignore podcast name from feed, it's inconsistent
-rawname="$5"
-artwork_url="$6"
-rawdate="$7"
+speed="$2"
+rawdir="$3"
+url="$4"
+# rawdir="$5"  # ignore podcast name from feed, it's inconsistent
+rawname="$6"
+artwork_url="$7"
+rawdate="$8"
 echo "RAWDATE: $rawdate"
 album=$(echo "$rawdir" | tr "-" " " | tr -d "[:punct:]")
 song=$(echo "$rawname" | tr "-" " " | tr -d "[:punct:]")
@@ -40,5 +41,13 @@ if [[ ${?} -eq 1 || ${?} -eq 2 ]]; then
     wget "$url" -O "$target_path"
     id3v2 --album "$album" --song "$song" "$target_path"
     echo "${local_path}" >> "${download_log}"
+
+    # If desired speed is different than 1, change the speed
+    if [[ $(echo "$speed==1" | bc) -ne 1 ]]; then
+        mv $target_dir/$local_path "$target_dir/$dir/tmp.mp3"
+        ffmpeg -y -i "$target_dir/$dir/tmp.mp3" -filter:a "atempo=$speed" -vn $target_dir/$local_path
+        rm "$target_dir/$dir/tmp.mp3"
+    fi
+     
     # curl -qL $artwork_url > "$target_dir/$dir/artwork.jpg"  # assumes jpg
 fi


### PR DESCRIPTION
- If flag "-s" is provided, it's argument is desired speed of the podcasts
- ffmpeg is used to change the podcast speed as desired
- Max value is 2, due to ffmpeg limitations (although there are workarounds, wasn't deemed necessary to implement at this time)
- Original mp3 is replaced with the one with modified speed
- Useful for playback devices that lack a setting to change playback speed dynamically (such as Garmin watches)